### PR TITLE
Migrations support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,18 +1609,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1629,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ chrono = "0.4.38"
 jsonwebtoken = "9.3.0"
 notify = "7.0.0"
 papaya = "0.1.4"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
 sha2 = "0.10.8"
 sqlx = { version = "0.8.2", features = ["sqlite", "runtime-tokio", "json"] }
 tokio = { version = "1.41.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note: Will probably error since the db files I have tested with aren't included.
                 --header 'u_: b1a74559bea16b1521205f95f07a25ea2f09f49eb4e265fa6057036d1dff7c22' \
                 --header 'Content-Type: application/json' \
                 --data '{
-                    "base_query": "SELECT * FROM users WHERE username = ? AND first_name = ? AND age = ?;",
+                    "query": "SELECT * FROM users WHERE username = ? AND first_name = ? AND age = ?;",
                     "parts": ["rikardbq", "Rikard", 35]
                 }'
                 ```
@@ -41,8 +41,8 @@ Note: Will probably error since the db files I have tested with aren't included.
                 ```
 
     - Server paths
-        - POST["/migrate/{database}"]
-            - TBD
+        - POST["/{database}/m"]
+            - Migration endpoint
                 - possible solution will be keeping track of database migrations on the server and allowing database consumer to be "dumb" or just execute what comes in blindly and error.
                 - consumer-side lib should have a notion of migrations, through a migration file pointing to schema changes in some way, either from a file or inline
         - POST["/{database}"]

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 - [x] fix the query function to allow more generic argument lists / partial application of query params
 - [x] Handle different types of calls, I.E inserts vs fetches, etc (pass a subject in the token?)
 - [x] Add web controllers in web lib
-- [-] setup rest endpoints for actual use
+- [x] setup rest endpoints for actual use
     - [x] "{database}" more or less done
     - [x] "{database}/m" (for running migrations)
         - use special table for book keeping of migrations. "dbName.<table>" as "dbName.\_\_migrations_tracker_t\_\_"
@@ -23,7 +23,7 @@
         - 1 folder per db to better namespace them on the filesystem since SQLite adds a bunch of meta files when manipulating the DB
 - [x] use build.rs file with sane defaults
     - SERF_ROOT_DIR env in build script, defaults to ./serf from the project root dir when in dev
-        - defaults(arch) in build scripts
+        - defaults(arch dependent) in build scripts
             - [x] win: %APPDATA%\.serf
             - [] unix: $HOME/.serf
     - folders will be created and populated with necessary files
@@ -31,6 +31,22 @@
 - [x] change usage of name "base_query in dat claim" to "query"
 - [] break out mutation and query logic into separate endpoints???
 - [] use middleware to check headers
+- [] CACHE queries
+    - post-processing step, I.E storing the data in CACHE and any potential tokenization \
+    of query is done in a separate thread as soon as possible. \
+    Caller thread still returns data to the user without waiting on any caching step.
+    - use papaya concurrent hashmap
+        - keyed on query as a whole?
+        - keyed on tokenized query?
+            - use SQL keywords as delimiter?
+                - SELECT * FROM users a LEFT JOIN something b ON b.name = a.name WHERE a.name = ?
+                    (base64 or hash of the query string) : {
+                        // find tables by splitting on FROM and JOINS
+                        affected_tables: ["users", "something"]
+                    }
+    
+    - CACHE busting will be done as a post-processing step to a write operation
+        - possibly by finding if the table written to is in any of the tokenized query keys for the database in question
 ---
 
 ### BRANCH MIGRATIONS

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,12 @@
 - [x] Add web controllers in web lib
 - [-] setup rest endpoints for actual use
     - [x] "{database}" more or less done
-    - [] "{database}/migrate" (for running migrations)
-        - scripts and management of these will have to be done on consumer side unless sqlx migrate has some feature for keeping track. Possibly both are needed to avoid calling the server when not needed.
+    - [x] "{database}/m" (for running migrations)
+        - use special table for book keeping of migrations. "dbName.<table>" as "dbName.\_\_migrations_tracker_t\_\_"
+        - versioning can be determined with chrono crate I.E datetime where 20241126180330 is YYYYmmddHHMMSS format
+        - migrations will be of similar type as mutation requests
+        - consumer side will bundle together all migrations that are still not applied
+        - expectation at migration endpoint is that there are possibly many queries to be applied
 - [-] start work on the CLI for adding users to user management db
     - [-] basic idea is to manage users with add, remove, modify commands (may have to use some library to manage sub-commanding)
     - same pattern would apply for managing DB's and user access to DB's (not final)
@@ -22,9 +26,21 @@
         - defaults(arch) in build scripts
             - [x] win: %APPDATA%\.serf
             - [] unix: $HOME/.serf
-                - at build replace the values with either the sane defaults or provided args.
     - folders will be created and populated with necessary files
+- [x] use transactions for mutations
+- [x] change usage of name "base_query in dat claim" to "query"
+- [] break out mutation and query logic into separate endpoints???
+- [] use middleware to check headers
 ---
+
+### BRANCH MIGRATIONS
+---
+- [x] Set up migrations (  {database}/m  ) endpoint
+- [x] Handle multiple migrations coming to endpoint as bundle
+- [x] Enforce shape of migration entry from consumer-side
+- [x] Create custom table for tracking migrations. \_\_migrations_tracker_t\_\_
+- [x] Add migrations support to JS connector lib, I.E consumer-side tracking file + some form of migration verification step.
+- [x] Apply migrations 1 by 1
 
 ### BRANCH WORK/DECLUTTER
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -36,14 +36,27 @@
     of query is done in a separate thread as soon as possible. \
     Caller thread still returns data to the user without waiting on any caching step.
     - use papaya concurrent hashmap
-        - keyed on query as a whole?
-        - keyed on tokenized query?
-            - use SQL keywords as delimiter?
-                - SELECT * FROM users a LEFT JOIN something b ON b.name = a.name WHERE a.name = ?
-                    (base64 or hash of the query string) : {
-                        // find tables by splitting on FROM and JOINS
-                        affected_tables: ["users", "something"]
-                    }
+        - use base64 encoded version of the query
+            - SELECT * FROM users a LEFT JOIN something b ON b.name = a.name WHERE a.name = ?
+                
+                hashmap_1
+                (base64-query-string) : struct { 
+                    expires?: timestamp(can be updated),
+                    data: JsonValue 
+                }
+
+                hashmap_2
+                (table name) : [
+                    (base64-query-string_1),
+                    (base64-query-string_2),
+                    (base64-query-string_3),
+                    (base64-query-string_4)
+                ]
+
+                (on write check hashmap_2 if the table written to exists in the map)
+                (if true then use the array it stores as a value and remove all the entries from hashmap_1 that matches the hashmap_2 value array items)
+
+
     
     - CACHE busting will be done as a post-processing step to a write operation
         - possibly by finding if the table written to is in any of the tokenized query keys for the database in question

--- a/src/core/constants/queries.rs
+++ b/src/core/constants/queries.rs
@@ -13,9 +13,9 @@ pub const GET_USERS_AND_ACCESS: &str = r#"
 
 pub const CREATE_USERS_TABLE: &str = r#"
     CREATE TABLE IF NOT EXISTS users (
-        id INTEGER PRIMARY KEY, 
-        username TEXT NOT NULL UNIQUE, 
-        username_hash TEXT NOT NULL UNIQUE, 
+        id INTEGER PRIMARY KEY,
+        username TEXT NOT NULL UNIQUE,
+        username_hash TEXT NOT NULL UNIQUE,
         username_password_hash TEXT NOT NULL
     );
 "#;
@@ -47,5 +47,21 @@ pub const INSERT_USER_DATABASE_ACCESS: &str = r#"
         database,
         access_right,
         username_hash
-    ) VALUES (?, ?, ?);
+    ) VALUES(?, ?, ?);
+"#;
+
+pub const CREATE_MIGRATIONS_TABLE: &str = r#"
+    CREATE TABLE IF NOT EXISTS __migrations_tracker_t__ (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        query TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_name ON __migrations_tracker_t__ (name);
+"#;
+
+pub const INSERT_MIGRATION: &str = r#"
+    INSERT INTO __migrations_tracker_t__(
+        name,
+        query
+    ) VALUES(?, ?);
 "#;

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -57,9 +57,7 @@ fn apply_query<'q>(
 ) -> Query<'q, Sqlite, <Sqlite as Database>::Arguments<'q>> {
     let args = match args {
         Some(args) if !args.is_empty() => args,
-        _ => {
-            return query;
-        }
+        _ => return query,
     };
 
     let [first, tail @ ..] = args.as_slice() else {

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,6 +1,6 @@
 use core::str;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{borrow::Borrow, sync::Arc};
 
 use actix_web::web;
 use sqlx::sqlite::SqlitePoolOptions;

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,6 +1,6 @@
 use core::str;
-use std::sync::Arc;
 use std::time::Duration;
+use std::{borrow::Borrow, sync::Arc};
 
 use actix_web::web;
 use sqlx::sqlite::SqlitePoolOptions;
@@ -101,14 +101,14 @@ pub struct Error<'a> {
 }
 
 impl<'a> Error<'a> {
-    fn new(message: &'a str) -> Self {
+    pub fn new(message: &'a str) -> Self {
         Error {
             message: message,
             reason: None,
         }
     }
 
-    fn with_reason(self, reason: ErrorReason) -> Self {
+    pub fn with_reason(self, reason: ErrorReason) -> Self {
         Error {
             reason: Some(reason),
             ..self
@@ -116,7 +116,10 @@ impl<'a> Error<'a> {
     }
 }
 
-pub fn get_flag_val<'a, T>(args: &'a Vec<String>, flag: &'a str) -> Option<T> where T: std::str::FromStr {
+pub fn get_flag_val<'a, T>(args: &'a Vec<String>, flag: &'a str) -> Option<T>
+where
+    T: std::str::FromStr,
+{
     let mut res = None;
 
     for i in 0..args.len() - 1 {
@@ -201,32 +204,44 @@ pub async fn get_query_result_claims<'a>(
 ) -> Result<Claims, Error<'a>> {
     let dat: RequestQuery = serde_json::from_str(&query_claims.dat).unwrap();
     let response_claims_result = match query_claims.sub {
-        Sub::M_ => {
+        Sub::MUTATE => {
             if user_access >= 2 {
-                let result =
-                    execute_query(AppliedQuery::new(&dat.base_query).with_args(dat.parts), db)
-                        .await
-                        .unwrap()
-                        .rows_affected();
+                let mut transaction = db.begin().await.unwrap();
 
-                Ok(generate_claims(
-                    serde_json::to_string(&result).unwrap(),
-                    Sub::D_,
-                ))
+                match execute_query(
+                    AppliedQuery::new(&dat.query).with_args(dat.parts),
+                    &mut *transaction,
+                )
+                .await
+                {
+                    Ok(res) => {
+                        let _ = &mut transaction.commit().await;
+
+                        Ok(generate_claims(
+                            serde_json::to_string(&res.rows_affected()).unwrap(),
+                            Sub::DATA,
+                        ))
+                    }
+                    Err(_) => {
+                        let _ = &mut transaction.rollback().await;
+
+                        Err(Error::new(errors::ERROR_UNSPECIFIED))
+                    }
+                }
             } else {
                 Err(Error::new(errors::ERROR_FORBIDDEN).with_reason(ErrorReason::UserNotAllowed))
             }
         }
-        Sub::F_ => {
+        Sub::FETCH => {
             if user_access >= 1 {
                 let result =
-                    fetch_all_as_json(AppliedQuery::new(&dat.base_query).with_args(dat.parts), &db)
+                    fetch_all_as_json(AppliedQuery::new(&dat.query).with_args(dat.parts), &db)
                         .await
                         .unwrap();
 
                 Ok(generate_claims(
                     serde_json::to_string(&result).unwrap(),
-                    Sub::D_,
+                    Sub::DATA,
                 ))
             } else {
                 Err(Error::new(errors::ERROR_FORBIDDEN).with_reason(ErrorReason::UserNotAllowed))

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -149,21 +149,13 @@ pub fn get_user_entry_and_access<'a>(
     let usr_clone: Arc<papaya::HashMap<String, Usr>> = Arc::clone(&data.usr);
     let usr = usr_clone.pin();
 
-    let user_entry_for_id = match usr.get(header_u_) {
-        Some(u) => u,
-        None => {
-            return Err(errors::ERROR_UNKNOWN_USER);
-        }
-    };
-
-    let user_access_right = match user_entry_for_id.db_ar.get(database_name) {
-        Some(ar) => ar,
-        None => {
-            return Err(errors::ERROR_USER_NO_DATABASE_ACCESS);
-        }
-    };
-
-    Ok((user_entry_for_id.to_owned(), *user_access_right))
+    match usr.get(header_u_) {
+        Some(u) => match u.db_ar.get(database_name) {
+            Some(ar) => Ok((u.to_owned(), *ar)),
+            None => Err(errors::ERROR_USER_NO_DATABASE_ACCESS),
+        },
+        None => Err(errors::ERROR_UNKNOWN_USER),
+    }
 }
 
 pub async fn get_database_connections<'a>(

--- a/src/web/controller/database.rs
+++ b/src/web/controller/database.rs
@@ -139,9 +139,7 @@ async fn handle_database_post(
     let (user_entry, user_access) =
         match get_user_entry_and_access(&data, header_u_, &database_name) {
             Ok(ue) => ue,
-            Err(err) => {
-                return HttpResponse::Unauthorized().json(ResponseResult::new().error(err));
-            }
+            Err(err) => return HttpResponse::Unauthorized().json(ResponseResult::new().error(err)),
         };
 
     let payload_token = &req_body.payload;
@@ -155,9 +153,7 @@ async fn handle_database_post(
 
     let db = match get_database_connections(&data, &database_name).await {
         Ok(conn) => conn,
-        Err(err) => {
-            return HttpResponse::NotFound().json(ResponseResult::new().error(err));
-        }
+        Err(err) => return HttpResponse::NotFound().json(ResponseResult::new().error(err)),
     };
 
     let query_result_claims =
@@ -212,12 +208,10 @@ async fn handle_database_migration_post(
     let (user_entry, user_access) =
         match get_user_entry_and_access(&data, header_u_, &database_name) {
             Ok(ue) => ue,
-            Err(err) => {
-                return HttpResponse::Unauthorized().json(ResponseResult::new().error(err));
-            }
+            Err(err) => return HttpResponse::Unauthorized().json(ResponseResult::new().error(err)),
         };
 
-    if user_access < 3 {
+    if user_access < 2 {
         return HttpResponse::Forbidden()
             .json(ResponseResult::new().error(errors::ERROR_USER_NOT_ALLOWED));
     }
@@ -233,9 +227,7 @@ async fn handle_database_migration_post(
 
     let db = match get_database_connections(&data, &database_name).await {
         Ok(conn) => conn,
-        Err(err) => {
-            return HttpResponse::NotFound().json(ResponseResult::new().error(err));
-        }
+        Err(err) => return HttpResponse::NotFound().json(ResponseResult::new().error(err)),
     };
 
     let claims = decoded_token.claims;
@@ -283,7 +275,7 @@ async fn handle_database_migration_post(
             let _ = &mut transaction.rollback().await;
             panic!("{err}");
         }
-    }
+    };
 
     // apply migration
     let res = match execute_query(AppliedQuery::new(&migration.query), &mut *transaction).await {

--- a/src/web/controller/database.rs
+++ b/src/web/controller/database.rs
@@ -2,12 +2,16 @@ use actix_web::{post, web, HttpRequest, HttpResponse, Responder};
 
 use crate::{
     core::{
-        constants::errors::{self, ErrorReason},
+        constants::{
+            errors::{self, ErrorReason},
+            queries,
+        },
+        db::{execute_query, AppliedQuery, QueryArg},
         state::AppState,
         util::{get_database_connections, get_query_result_claims, get_user_entry_and_access},
     },
     web::{
-        jwt::{decode_token, generate_token},
+        jwt::{decode_token, generate_claims, generate_token, RequestMigration, Sub},
         request::{RequestBody, ResponseResult},
     },
 };
@@ -110,6 +114,7 @@ async fn echo(
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(handle_database_post);
+    cfg.service(handle_database_migration_post);
 }
 
 #[post("/{database}")]
@@ -131,7 +136,6 @@ async fn handle_database_post(
     };
 
     let database_name = path.into_inner();
-
     let (user_entry, user_access) =
         match get_user_entry_and_access(&data, header_u_, &database_name) {
             Ok(ue) => ue,
@@ -140,19 +144,19 @@ async fn handle_database_post(
             }
         };
 
-    let db = match get_database_connections(&data, &database_name).await {
-        Ok(conn) => conn,
-        Err(err) => {
-            return HttpResponse::NotFound().json(ResponseResult::new().error(err));
-        }
-    };
-
-    let token = &req_body.payload;
-    let decoded_token = match decode_token(&token, &user_entry.up_hash) {
+    let payload_token = &req_body.payload;
+    let decoded_token = match decode_token(&payload_token, &user_entry.up_hash) {
         Ok(dec) => dec,
         Err(err) => {
             return HttpResponse::NotAcceptable()
                 .json(ResponseResult::new().error(&format!("ERROR={:?}", err.kind())))
+        }
+    };
+
+    let db = match get_database_connections(&data, &database_name).await {
+        Ok(conn) => conn,
+        Err(err) => {
+            return HttpResponse::NotFound().json(ResponseResult::new().error(err));
         }
     };
 
@@ -171,7 +175,7 @@ async fn handle_database_post(
                 }
 
                 return HttpResponse::InternalServerError()
-                    .json(ResponseResult::new().error(errors::ERROR_UNSPECIFIED));
+                    .json(ResponseResult::new().error(err.message));
             }
         };
 
@@ -182,6 +186,118 @@ async fn handle_database_post(
                 .json(ResponseResult::new().error(&format!("ERROR={:?}", err.kind())))
         }
     };
+
+    HttpResponse::Ok().json(ResponseResult::new().payload(token))
+}
+
+#[post("/{database}/m")]
+async fn handle_database_migration_post(
+    req: HttpRequest,
+    data: web::Data<AppState>,
+    path: web::Path<String>,
+    req_body: web::Json<RequestBody>,
+) -> impl Responder {
+    let header_u_ = match req.headers().get("u_") {
+        Some(hdr) => hdr.to_str().unwrap(),
+        _ => {
+            return HttpResponse::BadRequest().json(ResponseResult::new().error(format!(
+                "{} [ {} ]",
+                errors::ERROR_MISSING_HEADER,
+                "u_"
+            )));
+        }
+    };
+
+    let database_name = path.into_inner();
+    let (user_entry, user_access) =
+        match get_user_entry_and_access(&data, header_u_, &database_name) {
+            Ok(ue) => ue,
+            Err(err) => {
+                return HttpResponse::Unauthorized().json(ResponseResult::new().error(err));
+            }
+        };
+
+    if user_access < 3 {
+        return HttpResponse::Forbidden()
+            .json(ResponseResult::new().error(errors::ERROR_USER_NOT_ALLOWED));
+    }
+
+    let payload_token = &req_body.payload;
+    let decoded_token = match decode_token(&payload_token, &user_entry.up_hash) {
+        Ok(dec) => dec,
+        Err(err) => {
+            return HttpResponse::NotAcceptable()
+                .json(ResponseResult::new().error(&format!("ERROR={:?}", err.kind())))
+        }
+    };
+
+    let db = match get_database_connections(&data, &database_name).await {
+        Ok(conn) => conn,
+        Err(err) => {
+            return HttpResponse::NotFound().json(ResponseResult::new().error(err));
+        }
+    };
+
+    let claims = decoded_token.claims;
+    if claims.sub != Sub::MIGRATE {
+        return HttpResponse::NotAcceptable()
+            .json(ResponseResult::new().error(errors::ERROR_INVALID_SUBJECT));
+    }
+
+    let migration: RequestMigration = serde_json::from_str(&claims.dat).unwrap();
+    // let bundled_args: Vec<QueryArg> = migrations.iter().flat_map(|m| m.parts.clone()).collect();
+    // let bundled_queries: String = .migrations
+    //     .iter()
+    //     .flat_map(|m| m.query.chars())
+    //     .collect();
+
+    // start transaction here because we want to fail everything if we can't insert migration state
+    // or if we fail any of these steps in any way
+    let mut transaction = db.begin().await.unwrap();
+
+    // create migration table and panic if fail
+    match execute_query(
+        AppliedQuery::new(queries::CREATE_MIGRATIONS_TABLE),
+        &mut *transaction,
+    )
+    .await
+    {
+        Ok(_) => {
+            match execute_query(
+                AppliedQuery::new(queries::INSERT_MIGRATION).with_args(vec![
+                    QueryArg::String(&migration.name),
+                    QueryArg::String(&migration.query),
+                ]),
+                &mut *transaction,
+            )
+            .await
+            {
+                Ok(_) => {}
+                Err(err) => {
+                    let _ = &mut transaction.rollback().await;
+                    panic!("{err}");
+                }
+            }
+        }
+        Err(err) => {
+            let _ = &mut transaction.rollback().await;
+            panic!("{err}");
+        }
+    }
+
+    // apply migration
+    let res = match execute_query(AppliedQuery::new(&migration.query), &mut *transaction).await {
+        Ok(_) => {
+            let _ = &mut transaction.commit().await;
+            generate_claims(true.to_string(), Sub::DATA)
+        }
+        Err(err) => {
+            let _ = &mut transaction.rollback().await;
+            println!("{err}");
+            generate_claims(false.to_string(), Sub::DATA)
+        }
+    };
+    let token = generate_token(res, &user_entry.up_hash).unwrap();
 
     HttpResponse::Ok().json(ResponseResult::new().payload(token))
 }

--- a/src/web/controller/token_test.rs
+++ b/src/web/controller/token_test.rs
@@ -41,7 +41,7 @@ async fn handle_generate_token(
         }
     };
 
-    let claims = generate_claims(req_body, Sub::F_);
+    let claims = generate_claims(req_body, Sub::FETCH);
     let token = generate_token(claims, &user_entry_for_id.up_hash).unwrap();
 
     return HttpResponse::Ok().body(token);


### PR DESCRIPTION
#### Add rudimentary support for migrations.

FUTURE TODO's
---
store migration sha256 sum
handle migration undo scripts(currently only "unidirectional application of scripts")
add server-side / consumer-side synchronization with respect to the migrations tracker table

---
### BRANCH MIGRATIONS
---
- [x] Set up migrations (  {database}/m  ) endpoint
- [x] Handle multiple migrations coming to endpoint as bundle
- [x] Enforce shape of migration entry from consumer-side
- [x] Create custom table for tracking migrations. \_\_migrations_tracker_t\_\_
- [x] Add migrations support to JS connector lib, I.E consumer-side tracking file + some form of migration verification step.
- [x] Apply migrations 1 by 1

